### PR TITLE
feat: add Open Graph meta tags for LinkedIn and social sharing

### DIFF
--- a/layouts/partials/head/meta.html
+++ b/layouts/partials/head/meta.html
@@ -1,0 +1,65 @@
+<meta charset="UTF-8" />
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }}{{ end }}</title>
+<meta
+    name="description"
+    content="{{ if .IsPage }}{{ or .Params.description .Summary }}{{ else if .IsHome }}{{ .Site.Params.description }}{{ else if .IsNode }}{{ or .Params.description .Summary }}{{ end }}"
+/>
+<link rel="canonical" href="{{ .Permalink }}" />
+<link rel="robots" href="/robots.txt" />
+
+<!-- Open Graph / LinkedIn / Social sharing -->
+<meta property="og:site_name" content="{{ .Site.Title }}" />
+<meta property="og:url" content="{{ .Permalink }}" />
+{{ if .IsPage }}
+<meta property="og:type" content="article" />
+<meta property="og:title" content="{{ .Title }}" />
+<meta property="og:description" content="{{ or .Params.description .Summary }}" />
+{{ with .Params.image }}
+<meta property="og:image" content="{{ . | absURL }}" />
+{{ else }}
+<meta property="og:image" content="{{ "img/profile-picture.jpg" | absURL }}" />
+{{ end }}
+{{ with .Date }}
+<meta property="article:published_time" content="{{ .Format "2006-01-02T15:04:05Z07:00" }}" />
+{{ end }}
+{{ with .Lastmod }}
+<meta property="article:modified_time" content="{{ .Format "2006-01-02T15:04:05Z07:00" }}" />
+{{ end }}
+{{ else }}
+<meta property="og:type" content="website" />
+<meta property="og:title" content="{{ .Site.Title }}" />
+<meta property="og:description" content="{{ .Site.Params.description }}" />
+<meta property="og:image" content="{{ "img/profile-picture.jpg" | absURL }}" />
+{{ end }}
+
+<!-- Twitter Card -->
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="{{ if .IsPage }}{{ .Title }}{{ else }}{{ .Site.Title }}{{ end }}" />
+<meta name="twitter:description" content="{{ if .IsPage }}{{ or .Params.description .Summary }}{{ else }}{{ .Site.Params.description }}{{ end }}" />
+{{ if .IsPage }}
+{{ with .Params.image }}
+<meta name="twitter:image" content="{{ . | absURL }}" />
+{{ else }}
+<meta name="twitter:image" content="{{ "img/profile-picture.jpg" | absURL }}" />
+{{ end }}
+{{ else }}
+<meta name="twitter:image" content="{{ "img/profile-picture.jpg" | absURL }}" />
+{{ end }}
+
+<!-- Google Analytics -->
+<script
+    defer
+    src="https://www.googletagmanager.com/gtag/js?id={{ .Site.Config.Services.GoogleAnalytics.ID }}"
+></script>
+<script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() {
+        dataLayer.push(arguments);
+    }
+    gtag("js", new Date());
+
+    gtag("config", "{{ .Site.Config.Services.GoogleAnalytics.ID }}");
+</script>
+<!-- End Google Analytics -->


### PR DESCRIPTION
## Summary

- The `lowkey` theme had no Open Graph meta tags, causing LinkedIn (and other social networks) to display nothing when sharing posts
- Created `layouts/partials/head/meta.html` to override the theme's partial with proper OG support
- Added Twitter Card tags as well for completeness

## Changes

- `og:title`, `og:description`, `og:url`, `og:type`, `og:image` for all pages
- `og:type: article` + `article:published_time` / `article:modified_time` for posts
- Falls back to `img/profile-picture.jpg` if no `image` is set in post frontmatter
- Twitter Card tags (`summary_large_image`)

## Test plan

- [ ] Build the site locally and inspect the `<head>` of a post page to confirm OG tags are present
- [ ] Validate using the [LinkedIn Post Inspector](https://www.linkedin.com/post-inspector/) after deploying

🤖 Generated with [Claude Code](https://claude.com/claude-code)