### PR TITLE
fix: add responsive horizontal padding for mobile and tablet

### DIFF
--- a/themes/minetto/assets/css/main.css
+++ b/themes/minetto/assets/css/main.css
@@ -65,7 +65,7 @@
    Componentes / utilitários
    =========================================================== */
 @layer components {
-  .container-prose { @apply mx-auto w-full max-w-prose px-4 lg:px-0; }
+  .container-prose { @apply mx-auto w-full max-w-prose; }
 
   /* Header */
   #site-title { @apply text-center font-sans text-4xl font-extrabold tracking-tight text-ink sm:text-left dark:text-night-text; }

--- a/themes/minetto/layouts/_default/baseof.html
+++ b/themes/minetto/layouts/_default/baseof.html
@@ -8,7 +8,7 @@
     {{- partial "head/index" . -}}
   </head>
 
-  <body class="mx-auto max-w-screen-md font-serif antialiased">
+  <body class="mx-auto max-w-screen-md px-5 sm:px-8 md:px-0 font-serif antialiased">
     <a class="skip-link" href="#content">{{ i18n "skipToContent" | default "Skip to content" }}</a>
 
     <div class="site-header-bar">

--- a/themes/minetto/layouts/partials/footer/index.html
+++ b/themes/minetto/layouts/partials/footer/index.html
@@ -1,4 +1,4 @@
-<footer class="flex flex-col items-center gap-4 px-4 py-12 lg:px-0">
+<footer class="flex flex-col items-center gap-4 py-12">
   {{ partial "footer/social" . }}
   {{ partial "footer/copyright" . }}
 </footer>

--- a/themes/minetto/layouts/partials/header/nav.html
+++ b/themes/minetto/layouts/partials/header/nav.html
@@ -1,5 +1,5 @@
 <nav>
-  <ul class="px-4 lg:px-0">
+  <ul>
     {{ $currentPage := . }}
     {{ range site.Menus.main }}
       {{- $item := (cond (strings.HasSuffix .URL "/") .URL (printf "%s/" .URL)) | absLangURL -}}


### PR DESCRIPTION
Add px-5 (20px) on phones and sm:px-8 (32px) on small tablets to <body>, with md:px-0 so desktops keep the existing max-w-screen-md centering. Remove redundant px-4/lg:px-0 from nav, footer, and container-prose that would have doubled up with the body padding.

Fixes content (headings, post list, nav, footer) touching screen edges on iPhone and other narrow viewports.